### PR TITLE
Contain performance problem when end users upload super big photos

### DIFF
--- a/lib/attache/resize_job.rb
+++ b/lib/attache/resize_job.rb
@@ -1,12 +1,44 @@
+require 'digest/sha1'
+
 class Attache::ResizeJob
-  def perform(closed_file, geometry, extension)
+  def perform(closed_file, target_geometry_string, extension)
+    t = Time.now
     Attache.logger.info "[POOL] start"
-    thumbnail = Paperclip::Thumbnail.new(closed_file, geometry: geometry, format: extension)
+    thumbnail = thumbnail_for(closed_file: closed_file, target_geometry_string: target_geometry_string, extension: extension)
     thumbnail.instance_variable_set('@basename', thumbnail.instance_variable_get('@basename').gsub(/[^\w\.]/, '_'))
     thumbnail.make.tap do
-      Attache.logger.info "[POOL] done"
+      Attache.logger.info "[POOL] done in #{Time.now - t}s"
     end
   rescue Paperclip::Errors::NotIdentifiedByImageMagickError
     closed_file
   end
+
+  private
+
+    def thumbnail_for(closed_file:, target_geometry_string:, extension:, max: 2048)
+      thumbnail = Paperclip::Thumbnail.new(closed_file, geometry: target_geometry_string, format: extension)
+      current_geometry = current_geometry_for(thumbnail)
+      target_geometry = Paperclip::GeometryParser.new(target_geometry_string).make
+      if target_geometry.larger <= max && current_geometry.larger > max
+        # optimization:
+        #  when users upload "super big files", we can speed things up
+        #  by working from a "reasonably large 2048x2048 thumbnail" (<2 seconds)
+        #  instead of operating on the original (>10 seconds)
+        #  we store this reusably in Attache.cache to persist reboot, but not uploaded to cloud
+        working_geometry = "#{max}x#{max}>"
+        working_file = Attache.cache.fetch(Digest::SHA1.hexdigest(working_geometry + closed_file.path)) do
+          Attache.logger.info "[POOL] generate working_file"
+          Paperclip::Thumbnail.new(closed_file, geometry: working_geometry, format: extension).make
+        end
+        Attache.logger.info "[POOL] use working_file #{working_file.path}"
+        thumbnail = Paperclip::Thumbnail.new(working_file.tap(&:close), geometry: target_geometry_string, format: extension)
+      end
+      thumbnail
+    end
+
+    # allow stub in spec
+    def current_geometry_for(thumbnail)
+      thumbnail.current_geometry.tap(&:auto_orient)
+    end
+
 end

--- a/spec/lib/attache/resize_job_spec.rb
+++ b/spec/lib/attache/resize_job_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Attache::ResizeJob do
+  describe '#thumbnail_for' do
+    let(:max) { 2048 }
+    let(:current) { [1, 1] }
+    let(:current_w) { current.shift }
+    let(:current_h) { current.shift }
+    let(:job) { Attache::ResizeJob.new }
+    let(:original_path) { "spec/fixtures/transparent.gif" }
+
+    before {
+      allow(job).to receive(:current_geometry_for).and_return(Paperclip::Geometry.new(current_w, current_h))
+      Attache.cache.delete(Digest::SHA1.hexdigest("#{max}x#{max}>" + original_path))
+    }
+
+    subject {
+      job.send(:thumbnail_for, closed_file: File.new(original_path),
+                               target_geometry_string: target,
+                               extension: "gif").file.path
+    }
+
+    context 'target > max' do
+      let(:target) { ["#{max+1}x1>", "1x#{max+1}>"].sample }
+
+      it {
+        expect_any_instance_of(Paperclip::Thumbnail).not_to receive(:make)
+        is_expected.to eq(original_path)
+      }
+    end
+
+    context 'target <= max' do
+      let(:target) { ["#{max}x1>", "1x#{max}>"].sample }
+
+      context 'current > max' do
+        let(:current) { [max+1, 1].shuffle }
+
+        it {
+          expect_any_instance_of(Paperclip::Thumbnail).to receive(:make) do |instance|
+            expect(instance.target_geometry.to_s).to eq("#{max}x#{max}>")
+            File.new(original_path)
+          end
+          is_expected.not_to eq(original_path)
+        }
+      end
+
+      context 'current <= max' do
+        let(:current) { [max-1, 1].shuffle }
+
+        it {
+          expect_any_instance_of(Paperclip::Thumbnail).not_to receive(:make)
+          is_expected.to eq(original_path)
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
speed things up by working from a "reasonably large 2048x2048 thumbnail" (<2 seconds)
instead of always & only operating on the original file (>10 seconds)

we store this reusably in `Attache.cache` to persist reboot, but it is not uploaded to cloud storage

- first resize is "slow" (using original file) + "fast" (using working file)
- subsequent resizes is "fast" (using working file)
- thus, benefit kicks in only when
  - request to view big image in >1 dimension
  - or varnish/cdn cache is cold and local cache is hot
- does not affect uploaded files that are smaller than `2048` in height and width
