### PR TITLE
Serve PNG if file extension is not: png jpg jpeg gif

### DIFF
--- a/lib/attache/download.rb
+++ b/lib/attache/download.rb
@@ -1,6 +1,7 @@
 require 'connection_pool'
 
 class Attache::Download < Attache::Base
+  OUTPUT_EXTENSIONS = %w[png jpg jpeg gif]
   RESIZE_JOB_POOL = ConnectionPool.new(JSON.parse(ENV.fetch('RESIZE_POOL') { '{ "size": 2, "timeout": 60 }' }).symbolize_keys) { Attache::ResizeJob.new }
 
   def initialize(app)
@@ -30,6 +31,7 @@ class Attache::Download < Attache::Base
           file
         else
           extension = basename.split(/\W+/).last
+          extension = OUTPUT_EXTENSIONS.first unless OUTPUT_EXTENSIONS.index(extension.to_s.downcase)
           make_thumbnail_for(file.tap(&:close), geometry, extension)
         end
 

--- a/spec/lib/attache/download_spec.rb
+++ b/spec/lib/attache/download_spec.rb
@@ -53,16 +53,24 @@ describe Attache::Download do
         Attache.cache.write("example.com/#{reldirname}/#{filename}", file)
       end
 
-      it 'should send thumbnail' do
-        expect_any_instance_of(middleware.class).to receive(:make_thumbnail_for) do
-          Tempfile.new('download').tap do |t|
-            t.binmode
-            t.write IO.binread("spec/fixtures/transparent.gif")
-          end.tap(&:open)
+      context 'extension is for output' do
+        let(:filename) { "hello#{rand}.JPg" }
+
+        it 'should output as jpg' do
+          code, headers, body = subject.call
+          expect(code).to eq(200)
+          expect(headers['Content-Type']).to eq("image/jpeg")
         end
-        code, headers, body = subject.call
-        expect(code).to eq(200)
-        expect(headers['Content-Type']).to eq('image/gif')
+      end
+
+      context 'extension is not for output' do
+        let(:filename) { "hello#{rand}.PdF" }
+
+        it 'should output as png' do
+          code, headers, body = subject.call
+          expect(code).to eq(200)
+          expect(headers['Content-Type']).to eq('image/png')
+        end
       end
 
       context 'geometry is "original"' do


### PR DESCRIPTION
allows uploaded PDF to have PNG thumbnail instead of a broken image