### PR TITLE
Feature/outbox

### DIFF
--- a/lib/attache.rb
+++ b/lib/attache.rb
@@ -3,6 +3,7 @@ module Attache
     attr_accessor :localdir,
                   :vhost,
                   :cache,
+                  :outbox,
                   :logger
   end
 end
@@ -19,3 +20,6 @@ Attache.cache      = DiskStore.new(Attache.localdir, {
   reaper_interval:   ENV.fetch('CACHE_EVICTION_INTERVAL_SECONDS') { 60 }.to_i,
   eviction_strategy: (Attache.vhost.empty? ? nil : :LRU), # lru eviction only when there is remote storage
 })
+
+require './lib/attache/outbox.rb'
+Attache.outbox     = Attache::Outbox.new

--- a/lib/attache/base.rb
+++ b/lib/attache/base.rb
@@ -8,7 +8,8 @@ class Attache::Base
   end
 
   def vhost_for(host)
-    Attache::VHost.new(Attache.vhost[host])
+    config = Attache.vhost[host]
+    Attache::VHost.new(config && config.reverse_merge('HOSTNAME' => host))
   end
 
   def request_hostname(env)

--- a/lib/attache/base.rb
+++ b/lib/attache/base.rb
@@ -9,7 +9,7 @@ class Attache::Base
 
   def vhost_for(host)
     config = Attache.vhost[host]
-    Attache::VHost.new(config && config.reverse_merge('HOSTNAME' => host))
+    Attache::VHost.new(config && Hash('HOSTNAME' => host).merge(config))
   end
 
   def request_hostname(env)

--- a/lib/attache/job.rb
+++ b/lib/attache/job.rb
@@ -13,6 +13,9 @@ class Attache::Job
 
   if defined?(::SuckerPunch::Job)
     include ::SuckerPunch::Job
+    def later(sec, *args)
+      after(sec) { perform(*args) }
+    end
     def self.perform_async(*args)
       self.new.async.perform(*args)
     end

--- a/lib/attache/outbox.rb
+++ b/lib/attache/outbox.rb
@@ -8,5 +8,10 @@ class Attache::Outbox
   end
 
   def delete(hostname, relpath)
+    destpath = File.join(OUTBOX_DIR, hostname, relpath)
+    File.unlink(destpath)
+    Dir.unlink(destpath) while destpath = File.dirname(destpath)
+  rescue SystemCallError
+    # ignore delete failures
   end
 end

--- a/lib/attache/outbox.rb
+++ b/lib/attache/outbox.rb
@@ -1,0 +1,7 @@
+class Attache::Outbox
+  def write(hostname, relpath, io)
+  end
+
+  def delete(hostname, relpath)
+  end
+end

--- a/lib/attache/outbox.rb
+++ b/lib/attache/outbox.rb
@@ -1,5 +1,10 @@
 class Attache::Outbox
-  def write(hostname, relpath, io)
+  OUTBOX_DIR = ENV.fetch('OUTBOX_DIR') { 'outbox' }
+
+  def write(hostname, relpath, src)
+    destpath = File.join(OUTBOX_DIR, hostname, relpath)
+    FileUtils.mkdir_p(File.dirname destpath)
+    open(destpath, 'wb') {|dest| IO.copy_stream(src, dest) }
   end
 
   def delete(hostname, relpath)

--- a/lib/attache/upload.rb
+++ b/lib/attache/upload.rb
@@ -27,7 +27,7 @@ class Attache::Upload < Attache::Base
 
         if config.storage && config.bucket
           request.body.rewind if request.body.respond_to?(:rewind)
-          if Attache.outbox.write(request_hostname(env), relpath, request.body)
+          if Attache.outbox.write(request_hostname(env), relpath, request.body) > 0
             config.async(:storage_create, relpath: relpath, cachekey: cachekey)
           else
             return [500, config.headers_with_cors.merge('X-Exception' => 'Outbox file failed'), []]

--- a/lib/attache/upload.rb
+++ b/lib/attache/upload.rb
@@ -17,7 +17,7 @@ class Attache::Upload < Attache::Base
           end
         end
 
-        relpath = generate_relpath(params['file'])
+        relpath = generate_relpath(Attache::Upload.sanitize params['file'])
         cachekey = File.join(request_hostname(env), relpath)
 
         bytes_wrote = Attache.cache.write(cachekey, request.body)
@@ -54,6 +54,10 @@ class Attache::Upload < Attache::Base
     Attache.logger.error $@
     Attache.logger.error $!
     [500, { 'X-Exception' => $!.to_s }, []]
+  end
+
+  def self.sanitize(filename)
+    filename.to_s.gsub(/\%/, '_')
   end
 
   private

--- a/lib/attache/upload.rb
+++ b/lib/attache/upload.rb
@@ -25,7 +25,14 @@ class Attache::Upload < Attache::Base
           return [500, config.headers_with_cors.merge('X-Exception' => 'Local file failed'), []]
         end
 
-        config.async(:storage_create, relpath: relpath, cachekey: cachekey) if config.storage && config.bucket
+        if config.storage && config.bucket
+          request.body.rewind if request.body.respond_to?(:rewind)
+          if Attache.outbox.write(request_hostname(env), relpath, request.body)
+            config.async(:storage_create, relpath: relpath, cachekey: cachekey)
+          else
+            return [500, config.headers_with_cors.merge('X-Exception' => 'Outbox file failed'), []]
+          end
+        end
 
         file = Attache.cache.read(cachekey)
         file.close unless file.closed?

--- a/lib/attache/vhost.rb
+++ b/lib/attache/vhost.rb
@@ -51,6 +51,7 @@ class Attache::VHost
       body: Attache.cache.read(args[:cachekey]),
     })
     Attache.logger.info "[JOB] uploaded #{args[:cachekey]}"
+    Attache.outbox.delete(env['HOSTNAME'], args[:relpath]) if env['HOSTNAME'].present?
   end
 
   def storage_destroy(args)

--- a/spec/lib/attache/outbox_spec.rb
+++ b/spec/lib/attache/outbox_spec.rb
@@ -5,6 +5,7 @@ describe Attache::Outbox do
   let(:relpath)  { File.join(SecureRandom.hex.scan(/../), 'Exãmple#{rand}.gif') }
   let(:src) { "spec/fixtures/transparent.gif" }
   let(:io) { StringIO.new(IO.binread(src), 'rb') }
+  let(:destpath) { File.join(Attache::Outbox::OUTBOX_DIR, hostname, relpath) }
 
   after do
     FileUtils.rm_rf(File.join(Attache::Outbox::OUTBOX_DIR, hostname))
@@ -12,7 +13,6 @@ describe Attache::Outbox do
 
   describe '#write' do
     it "should write file into `OUTBOX_DIR/hostname/relpath`" do
-      destpath = File.join(Attache::Outbox::OUTBOX_DIR, hostname, relpath)
       expect {
         Attache.outbox.write(hostname, relpath, io)
       }.to change { File.exists?(destpath) }.to eq(true)
@@ -21,5 +21,16 @@ describe Attache::Outbox do
   end
 
   describe '#delete' do
+    before do
+      Attache.outbox.write(hostname, relpath, io)
+    end
+
+    it "should remove file from `OUTBOX_DIR/hostname/relpath`" do
+      expect {
+        Attache.outbox.delete(hostname, relpath)
+      }.to change { File.exists?(destpath) }.to eq(false)
+      expect(File.exists?(File.dirname(destpath))).to eq(false)
+      expect(File.exists?(File.dirname(File.dirname destpath))).to eq(false)
+    end
   end
 end

--- a/spec/lib/attache/outbox_spec.rb
+++ b/spec/lib/attache/outbox_spec.rb
@@ -1,7 +1,23 @@
 require 'spec_helper'
 
 describe Attache::Outbox do
+  let(:hostname) { "example.com" }
+  let(:relpath)  { File.join(SecureRandom.hex.scan(/../), 'Exãmple#{rand}.gif') }
+  let(:src) { "spec/fixtures/transparent.gif" }
+  let(:io) { StringIO.new(IO.binread(src), 'rb') }
+
+  after do
+    FileUtils.rm_rf(File.join(Attache::Outbox::OUTBOX_DIR, hostname))
+  end
+
   describe '#write' do
+    it "should write file into `OUTBOX_DIR/hostname/relpath`" do
+      destpath = File.join(Attache::Outbox::OUTBOX_DIR, hostname, relpath)
+      expect {
+        Attache.outbox.write(hostname, relpath, io)
+      }.to change { File.exists?(destpath) }.to eq(true)
+      expect(FileUtils.identical?(src, destpath)).to eq(true)
+    end
   end
 
   describe '#delete' do

--- a/spec/lib/attache/outbox_spec.rb
+++ b/spec/lib/attache/outbox_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Attache::Outbox do
+  describe '#write' do
+  end
+
+  describe '#delete' do
+  end
+end

--- a/spec/lib/attache/upload_spec.rb
+++ b/spec/lib/attache/upload_spec.rb
@@ -78,6 +78,7 @@ describe Attache::Upload do
       before do
         allow_any_instance_of(Attache::VHost).to receive(:storage).and_return(double(:storage))
         allow_any_instance_of(Attache::VHost).to receive(:bucket).and_return(double(:bucket))
+        allow_any_instance_of(Attache::VHost).to receive(:storage_create).and_return(nil)
       end
 
       it 'should save file remotely' do

--- a/spec/lib/attache/upload_spec.rb
+++ b/spec/lib/attache/upload_spec.rb
@@ -4,7 +4,7 @@ describe Attache::Upload do
   let(:app) { ->(env) { [200, env, "app"] } }
   let(:middleware) { Attache::Upload.new(app) }
   let(:params) { {} }
-  let(:filename) { "Exãmple#{rand}.gif" }
+  let(:filename) { "Exãmple %#{rand} %20.gif" }
   let(:file) { StringIO.new(IO.binread("spec/fixtures/transparent.gif"), 'rb') }
   let(:hostname) { "example.com" }
 
@@ -37,11 +37,11 @@ describe Attache::Upload do
       end
     end
 
-    it 'should wrote to cache with params[:file] as filename' do
+    it 'should wrote to cache with Attache::Upload.sanitize(params[:file]) as filename' do
       code, headers, body = subject.call
       json = JSON.parse(body.join(''))
       relpath = json['path']
-      expect(relpath).to end_with(params[:file])
+      expect(relpath).to end_with(Attache::Upload.sanitize params[:file])
       expect(Attache.cache.read(hostname + '/' + relpath).tap(&:close)).to be_kind_of(File)
     end
 

--- a/spec/lib/attache/upload_spec.rb
+++ b/spec/lib/attache/upload_spec.rb
@@ -4,7 +4,7 @@ describe Attache::Upload do
   let(:app) { ->(env) { [200, env, "app"] } }
   let(:middleware) { Attache::Upload.new(app) }
   let(:params) { {} }
-  let(:filename) { "hello#{rand}.gif" }
+  let(:filename) { "Exãmple#{rand}.gif" }
   let(:file) { StringIO.new(IO.binread("spec/fixtures/transparent.gif"), 'rb') }
   let(:hostname) { "example.com" }
 

--- a/spec/lib/attache/upload_spec.rb
+++ b/spec/lib/attache/upload_spec.rb
@@ -89,6 +89,18 @@ describe Attache::Upload do
         expect(Attache.outbox).to receive(:write).with(hostname, *any_args)
         subject.call
       end
+
+      context 'save outbox failed' do
+        before do
+          allow(Attache.outbox).to receive(:write).and_return(0)
+        end
+
+        it 'should respond with error' do
+          code, headers, body = subject.call
+          expect(code).to eq(500)
+          expect(headers['X-Exception']).to eq('Outbox file failed')
+        end
+      end
     end
 
     context 'with secret_key' do

--- a/spec/lib/attache/vhost_spec.rb
+++ b/spec/lib/attache/vhost_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Attache::VHost do
-  let(:config) { { 'REMOTE_DIR' => remotedir } }
+  let(:config) { { 'HOSTNAME' => 'example.com', 'REMOTE_DIR' => remotedir } }
   let(:vhost) { Attache::VHost.new(config) }
   let(:remote_api) { double(:remote_api) }
   let(:file_io) { StringIO.new("") }
@@ -17,6 +17,8 @@ describe Attache::VHost do
     it 'should read with cachekey, write with remotedir prefix' do
       expect(Attache.cache).to receive(:read).with(cachekey).and_return(file_io)
       expect(remote_api).to receive(:create).with(key: "#{remotedir}/#{relpath}", body: file_io)
+      expect(Attache.outbox).to receive(:delete).with(config['HOSTNAME'], 'relpath')
+
       vhost.storage_create(relpath: relpath, cachekey: cachekey)
     end
   end


### PR DESCRIPTION
Fixes #3 

- *before* we kick off uploading to cloud store, write to "outbox" with `hostname`, `relpath` and binary file 
- *after* successful cloud upload, delete from "outbox", `hostname`, `relpath` 