### PR TITLE
Add new geometry "remote" to access the file on cloud storage, skipping local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Whenever the main app wants to display the uploaded file, constrained to a parti
 > <img src="https://example.com/view/pre/fix/50x50%23/image123.jpg" />
 > ```
 > requesting for a geometry of `original` will return the uploaded file. this works well for non-image file uploads.
+> requesting for a geometry of `remote` will skip the local cache and serve from cloud storage.
 
 * Attache keeps the uploaded file in the local harddisk (a temp directory).
 * Attache will also upload the file into cloud storage if `FOG_CONFIG` is set

--- a/lib/attache/vhost.rb
+++ b/lib/attache/vhost.rb
@@ -37,11 +37,14 @@ class Attache::VHost
     Rack::Utils.secure_compare(params['hmac'], hmac_for("#{params['uuid']}#{params['expiration']}"))
   end
 
-  def storage_get(args)
-    url = remote_api.new({
+  def storage_url(args)
+    remote_api.new({
       key: File.join(*remotedir, args[:relpath]),
     }).url(Time.now + 60)
-    open(url)
+  end
+
+  def storage_get(args)
+    open storage_url(args)
   end
 
   def storage_create(args)

--- a/spec/lib/attache/download_spec.rb
+++ b/spec/lib/attache/download_spec.rb
@@ -45,6 +45,26 @@ describe Attache::Download do
           code, headers, body = subject.call
           expect(code).to eq(200)
         end
+
+        context 'geometry is "remote"' do
+          let(:remote_url) { "http://example.com/image.jpg" }
+          let(:geometry) { CGI.escape('remote') }
+
+          before do
+            allow_any_instance_of(Attache::VHost).to receive(:storage_url).and_return(remote_url)
+          end
+
+          it 'should send remote file' do
+            expect(Attache.cache).not_to receive(:fetch)
+            expect_any_instance_of(Attache::VHost).to receive(:storage_url)
+            code, headers, body = subject.call
+            response_content = ''
+            body.each {|p| response_content += p }
+            expect(response_content).to eq('')
+            expect(code).to eq(301)
+            expect(headers['Location']).to eq(remote_url)
+          end
+        end
       end
     end
 
@@ -75,6 +95,19 @@ describe Attache::Download do
 
       context 'geometry is "original"' do
         let(:geometry) { CGI.escape('original') }
+
+        it 'should send original file' do
+          expect_any_instance_of(middleware.class).not_to receive(:make_thumbnail_for)
+          code, headers, body = subject.call
+          response_content = ''
+          body.each {|p| response_content += p }
+          original_content = file.tap(&:rewind).read
+          expect(response_content).to eq(original_content)
+        end
+      end
+
+      context 'geometry is "remote"' do
+        let(:geometry) { CGI.escape('remote') }
 
         it 'should send original file' do
           expect_any_instance_of(middleware.class).not_to receive(:make_thumbnail_for)


### PR DESCRIPTION
Helpful to verify cloud content