### PR TITLE
Update fog since fog-aliyun is yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
       nokogiri
-    fog-aliyun (0.0.10)
+    fog-aliyun (0.1.0)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       ipaddress (~> 0.8)
@@ -133,7 +133,7 @@ GEM
     fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-softlayer (1.0.0)
+    fog-softlayer (1.0.2)
       fog-core
       fog-json
     fog-storm_on_demand (0.1.1)


### PR DESCRIPTION
I got the following when running `bundle install`
> Could not find fog-aliyun-0.0.10 in any of the sources

Ref: https://rubygems.org/gems/fog-aliyun/versions/0.0.10

Just a side note on whether should check in `Gemfile.lock`, not sure if this is still relevant. http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/