### PR TITLE
Require mutex for the same file (and resize of same file + same geometry)

### DIFF
--- a/lib/attache/download.rb
+++ b/lib/attache/download.rb
@@ -5,6 +5,14 @@ class Attache::Download < Attache::Base
 
   def initialize(app)
     @app = app
+    @mutexes = {}
+  end
+
+  def synchronize(key, &block)
+    mutex = @mutexes[key] ||= Mutex.new
+    mutex.synchronize(&block)
+  ensure
+    @mutexes.delete(key)
   end
 
   def _call(env, config)
@@ -23,52 +31,56 @@ class Attache::Download < Attache::Base
           return [302, headers, []]
         end
 
-        file = begin
-          cachekey = File.join(request_hostname(env), relpath)
-          Attache.cache.fetch(cachekey) do
-            name_with_vhost_pairs = vhosts.inject({}) { |sum,(k,v)| (v ? sum.merge(k => v) : sum) }
-            get_first_result_present_async(name_with_vhost_pairs.collect {|name, vhost|
-              lambda { Thread.handle_interrupt(BasicObject => :on_blocking) {
-                begin
-                  Attache.logger.info "[POOL] looking for #{name} #{relpath}..."
-                  vhost.storage_get(relpath: relpath).tap do |v|
-                    Attache.logger.info "[POOL] found #{name} #{relpath} = #{v.inspect}"
+        file = synchronize relpath do
+          begin
+            cachekey = File.join(request_hostname(env), relpath)
+            Attache.cache.fetch(cachekey) do
+              name_with_vhost_pairs = vhosts.inject({}) { |sum,(k,v)| (v ? sum.merge(k => v) : sum) }
+              get_first_result_present_async(name_with_vhost_pairs.collect {|name, vhost|
+                lambda { Thread.handle_interrupt(BasicObject => :on_blocking) {
+                  begin
+                    Attache.logger.info "[POOL] looking for #{name} #{relpath}..."
+                    vhost.storage_get(relpath: relpath).tap do |v|
+                      Attache.logger.info "[POOL] found #{name} #{relpath} = #{v.inspect}"
+                    end
+                  rescue Exception
+                    Attache.logger.error $!
+                    Attache.logger.error $@
+                    Attache.logger.info "[POOL] not found #{name} #{relpath}"
+                    nil
                   end
-                rescue Exception
-                  Attache.logger.error $!
-                  Attache.logger.error $@
-                  Attache.logger.info "[POOL] not found #{name} #{relpath}"
-                  nil
-                end
-              } }
-            })
+                } }
+              })
+            end
+          rescue Exception # Errno::ECONNREFUSED, OpenURI::HTTPError, Excon::Errors, Fog::Errors::Error
+            Attache.logger.error "ERROR REFERER #{env['HTTP_REFERER'].inspect}"
+            nil
           end
-        rescue Exception # Errno::ECONNREFUSED, OpenURI::HTTPError, Excon::Errors, Fog::Errors::Error
-          Attache.logger.error "ERROR REFERER #{env['HTTP_REFERER'].inspect}"
-          nil
         end
 
         unless file && file.try(:size).to_i > 0
           return [404, config.download_headers, []]
         end
 
-        thumbnail = case geometry
-        when 'original', *vhosts.keys
-          file
-        else
-          extension = basename.split(/\W+/).last
-          make_thumbnail_for(file.tap(&:close), geometry, extension, basename)
+        thumbnail = synchronize "#{relpath}#{geometry}" do
+          case geometry
+          when 'original', *vhosts.keys
+            file
+          else
+            cachekey_with_geometry = File.join(request_hostname(env), relpath, geometry)
+            tempfile = nil
+            Attache.cache.fetch(cachekey_with_geometry) do
+              extension = basename.split(/\W+/).last
+              tempfile = make_thumbnail_for(file.tap(&:close), geometry, extension, basename)
+            end.tap { File.unlink(tempfile.path) if tempfile.try(:path) }
+          end
         end
 
         headers = {
           'Content-Type' => content_type_of(thumbnail.path),
         }.merge(config.download_headers)
 
-        [200, headers, rack_response_body_for(thumbnail)].tap do
-          unless file == thumbnail # cleanup
-            File.unlink(thumbnail.path) rescue Errno::ENOENT
-          end
-        end
+        [200, headers, rack_response_body_for(thumbnail)]
       end
     else
       @app.call(env)

--- a/lib/attache/download.rb
+++ b/lib/attache/download.rb
@@ -8,13 +8,6 @@ class Attache::Download < Attache::Base
     @mutexes = {}
   end
 
-  def synchronize(key, &block)
-    mutex = @mutexes[key] ||= Mutex.new
-    mutex.synchronize(&block)
-  ensure
-    @mutexes.delete(key)
-  end
-
   def _call(env, config)
     case env['PATH_INFO']
     when %r{\A/view/}
@@ -31,50 +24,14 @@ class Attache::Download < Attache::Base
           return [302, headers, []]
         end
 
-        file = synchronize relpath do
-          begin
-            cachekey = File.join(request_hostname(env), relpath)
-            Attache.cache.fetch(cachekey) do
-              name_with_vhost_pairs = vhosts.inject({}) { |sum,(k,v)| (v ? sum.merge(k => v) : sum) }
-              get_first_result_present_async(name_with_vhost_pairs.collect {|name, vhost|
-                lambda { Thread.handle_interrupt(BasicObject => :on_blocking) {
-                  begin
-                    Attache.logger.info "[POOL] looking for #{name} #{relpath}..."
-                    vhost.storage_get(relpath: relpath).tap do |v|
-                      Attache.logger.info "[POOL] found #{name} #{relpath} = #{v.inspect}"
-                    end
-                  rescue Exception
-                    Attache.logger.error $!
-                    Attache.logger.error $@
-                    Attache.logger.info "[POOL] not found #{name} #{relpath}"
-                    nil
-                  end
-                } }
-              })
-            end
-          rescue Exception # Errno::ECONNREFUSED, OpenURI::HTTPError, Excon::Errors, Fog::Errors::Error
-            Attache.logger.error "ERROR REFERER #{env['HTTP_REFERER'].inspect}"
-            nil
-          end
-        end
-
-        unless file && file.try(:size).to_i > 0
-          return [404, config.download_headers, []]
-        end
-
-        thumbnail = synchronize "#{relpath}#{geometry}" do
-          case geometry
+        thumbnail = case geometry
           when 'original', *vhosts.keys
-            file
+            get_original_file(relpath, vhosts, env)
           else
-            cachekey_with_geometry = File.join(request_hostname(env), relpath, geometry)
-            tempfile = nil
-            Attache.cache.fetch(cachekey_with_geometry) do
-              extension = basename.split(/\W+/).last
-              tempfile = make_thumbnail_for(file.tap(&:close), geometry, extension, basename)
-            end.tap { File.unlink(tempfile.path) if tempfile.try(:path) }
+            get_thumbnail_file(geometry, basename, relpath, vhosts, env)
           end
-        end
+
+        return [404, config.download_headers, []] if thumbnail.try(:size).to_i == 0
 
         headers = {
           'Content-Type' => content_type_of(thumbnail.path),
@@ -98,11 +55,55 @@ class Attache::Download < Attache::Base
       yield dirname, geometry, basename, relpath
     end
 
-    def make_thumbnail_for(file, geometry, extension, basename)
-      Attache.logger.info "[POOL] new job"
-      RESIZE_JOB_POOL.with do |job|
-        job.perform(file, geometry, extension, basename)
+    def synchronize(key, &block)
+      mutex = @mutexes[key] ||= Mutex.new
+      mutex.synchronize(&block)
+    ensure
+      @mutexes.delete(key)
+    end
+
+    def get_thumbnail_file(geometry, basename, relpath, vhosts, env)
+      cachekey = File.join(request_hostname(env), relpath, geometry)
+      synchronize(cachekey) do
+        tempfile = nil
+        Attache.cache.fetch(cachekey) do
+          Attache.logger.info "[POOL] new job"
+          tempfile = RESIZE_JOB_POOL.with do |job|
+            job.perform(geometry, basename, relpath, vhosts, env) do
+              # opens up possibility that job implementation
+              # does not require we download original file prior
+              get_original_file(relpath, vhosts, env)
+            end
+          end
+        end.tap { File.unlink(tempfile.path) if tempfile.try(:path) }
       end
+    end
+
+    def get_original_file(relpath, vhosts, env)
+      cachekey = File.join(request_hostname(env), relpath)
+      synchronize(cachekey) do
+        Attache.cache.fetch(cachekey) do
+          name_with_vhost_pairs = vhosts.inject({}) { |sum,(k,v)| (v ? sum.merge(k => v) : sum) }
+          get_first_result_present_async(name_with_vhost_pairs.collect {|name, vhost|
+            lambda { Thread.handle_interrupt(BasicObject => :on_blocking) {
+              begin
+                Attache.logger.info "[POOL] looking for #{name} #{relpath}..."
+                vhost.storage_get(relpath: relpath).tap do |v|
+                  Attache.logger.info "[POOL] found #{name} #{relpath} = #{v.inspect}"
+                end
+              rescue Exception
+                Attache.logger.error $!
+                Attache.logger.error $@
+                Attache.logger.info "[POOL] not found #{name} #{relpath}"
+                nil
+              end
+            } }
+          })
+        end
+      end
+    rescue Exception # Errno::ECONNREFUSED, OpenURI::HTTPError, Excon::Errors, Fog::Errors::Error
+      Attache.logger.error "ERROR REFERER #{env['HTTP_REFERER'].inspect}"
+      nil
     end
 
     # Ref https://gist.github.com/sferik/39831f34eb87686b639c#gistcomment-1652888

--- a/lib/attache/resize_job.rb
+++ b/lib/attache/resize_job.rb
@@ -1,8 +1,12 @@
 require 'digest/sha1'
+require 'stringio'
 
 class Attache::ResizeJob
-  def perform(closed_file, target_geometry_string, extension, basename)
-    t = Time.now
+  def perform(target_geometry_string, basename, relpath, vhosts, env, t = Time.now)
+    closed_file = yield
+    return StringIO.new if closed_file.try(:size).to_i == 0
+
+    extension = basename.split(/\W+/).last
     Attache.logger.info "[POOL] start"
     return make_nonimage_preview(closed_file, basename) if ['pdf', 'txt'].include?(extension.to_s.downcase)
 

--- a/spec/lib/attache/download_spec.rb
+++ b/spec/lib/attache/download_spec.rb
@@ -116,7 +116,7 @@ describe Attache::Download do
         let(:geometry) { CGI.escape('original') }
 
         it 'should send original file' do
-          expect_any_instance_of(middleware.class).not_to receive(:make_thumbnail_for)
+          expect_any_instance_of(middleware.class).not_to receive(:get_thumbnail_file)
           code, headers, body = subject.call
           response_content = ''
           body.each {|p| response_content += p }


### PR DESCRIPTION
Requests for the same file (and/or same dimensions) are currently queued up to use the pool of resize workers. however, the resize work is actually duplicate (and s3 fetches are also duplicate).

By putting the same "work" behind mutex, we free up resources and speed up requests of those waiting behind the first worker.

One side effect is that we will now be caching resized thumbnails (see `cachekey_with_geometry`) which means we use more local disk (or higher eviction rate)

:eyes: @winston ?